### PR TITLE
fix(M2-review): green CI + address the three review findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,11 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ pnpm test:watch    # watch mode
 pnpm typecheck     # tsc project references build
 pnpm lint          # eslint
 pnpm format        # prettier --write
-pnpm play          # play a hand in the terminal vs. an always-call bot
+pnpm play          # play a hand in the terminal vs. the heuristic bot
 ```
 
 `pnpm verify` is exactly what the pre-push hook and CI run, so a clean `verify` means a green push.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -3,12 +3,13 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "description": "Thin terminal harness to play a hand against a trivial bot — the M0–M3 feedback loop.",
+  "description": "Thin terminal harness to play a hand against a heuristic bot — the M0–M3 feedback loop.",
   "scripts": {
     "play": "tsx src/play.ts",
     "typecheck": "tsc -b"
   },
   "dependencies": {
+    "@holdem/bots": "workspace:*",
     "@holdem/engine": "workspace:*"
   },
   "devDependencies": {

--- a/apps/cli/src/play.ts
+++ b/apps/cli/src/play.ts
@@ -1,7 +1,7 @@
 /**
- * `pnpm play` — a thin terminal harness to play heads-up hands against a trivial
- * "always-call" bot (ticket 0004). It drives the real {@link createHand} engine with no
- * UI, so it doubles as the fast feedback loop for the bots and coach built on top later.
+ * `pnpm play` — a thin terminal harness to play heads-up hands against the M2 heuristic
+ * bot (ticket 0004, wired to `@holdem/bots`). It drives the real {@link createHand} engine
+ * with no UI, so it doubles as the fast feedback loop for the bots and coach.
  *
  * You are the hero (seat 0); the bot is seat 1. Stacks carry between hands and the button
  * alternates; the session ends when you quit or someone busts. The engine never shuffles
@@ -19,13 +19,20 @@ import {
   type Card,
   type HandState,
 } from '@holdem/engine'
-import { alwaysCallBot, parseAction, renderState, renderResult, renderLegal } from './table.js'
+import { decisionContext, heuristicOpponent, TIGHT_AGGRESSIVE } from '@holdem/bots'
+import { parseAction, renderState, renderResult, renderLegal } from './table.js'
 
 const HERO = 0
 const BOT = 1
 const SMALL_BLIND = 1
 const BIG_BLIND = 2
 const STARTING_STACK = 200
+
+// One tight-aggressive opponent for the whole session. Its PRNG carries across hands, so
+// the aggression mix stays varied rather than replaying an identical line every hand; the
+// seed is randomised per session so two sittings differ. (Determinism lives in the tests,
+// not the play harness — the deck is already shuffled with Math.random here.)
+const bot = heuristicOpponent(TIGHT_AGGRESSIVE, Math.floor(Math.random() * 0x100000000))
 
 /** Fisher–Yates shuffle of a fresh deck (Math.random is fine for a play harness). */
 function shuffledDeck(): Card[] {
@@ -118,8 +125,9 @@ async function playHand(
       if (next === null) return null
       state = next
     } else {
-      const action = alwaysCallBot(legalActions(state))
-      console.log(`\nBot ${action.type}s.`)
+      const action = await Promise.resolve(bot.decide(decisionContext(state, BOT)))
+      const detail = 'amount' in action ? ` ${action.amount}` : ''
+      console.log(`\nBot ${action.type}s${detail}.`)
       state = applyAction(state, action)
     }
   }
@@ -130,7 +138,7 @@ async function playHand(
 }
 
 async function main(): Promise<void> {
-  console.log("Bachmann Hold'em — terminal harness. You vs. an always-call bot.")
+  console.log(`Bachmann Hold'em — terminal harness. You vs. ${bot.name ?? 'a bot'}.`)
   console.log(`Blinds ${SMALL_BLIND}/${BIG_BLIND}, starting stacks ${STARTING_STACK}.\n`)
 
   let stacks: [number, number] = [STARTING_STACK, STARTING_STACK]

--- a/apps/cli/src/table.test.ts
+++ b/apps/cli/src/table.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import type { LegalActions } from '@holdem/engine'
-import { alwaysCallBot, parseAction } from './table.js'
+import { parseAction } from './table.js'
 
 /** A legal-actions snapshot facing a bet: can fold, call 10, or raise to 20-100. */
 const facingBet: LegalActions = {
@@ -19,15 +19,6 @@ const canCheck: LegalActions = {
   bet: { min: 2, max: 100 },
   raise: null,
 }
-
-describe('alwaysCallBot', () => {
-  it('checks when checking is free', () => {
-    expect(alwaysCallBot(canCheck)).toEqual({ type: 'check' })
-  })
-  it('calls when facing a bet (never folds, never raises)', () => {
-    expect(alwaysCallBot(facingBet)).toEqual({ type: 'call' })
-  })
-})
 
 describe('parseAction', () => {
   it('reads single-letter and full-word verbs', () => {

--- a/apps/cli/src/table.ts
+++ b/apps/cli/src/table.ts
@@ -18,18 +18,6 @@ import {
 /** Result of parsing a line of human input: a legal action, or a message to reprint. */
 export type ParseResult = { ok: true; action: Action } | { ok: false; error: string }
 
-/**
- * The placeholder opponent: it never folds and never raises. It checks when it can and
- * otherwise calls. (`legalActions` returns the call amount already capped at its stack,
- * so a call here is an all-in when it is short.)
- */
-export function alwaysCallBot(legal: LegalActions): Action {
-  if (legal.check) return { type: 'check' }
-  if (legal.call) return { type: 'call' }
-  // Unreachable in heads-up play, but stay total: the only thing always offered is fold.
-  return { type: 'fold' }
-}
-
 /** A one-line, human-readable menu of the legal actions, with amounts. */
 export function renderLegal(legal: LegalActions): string {
   const parts: string[] = []

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -6,5 +6,5 @@
     "types": ["node"]
   },
   "include": ["src/**/*.ts"],
-  "references": [{ "path": "../../packages/engine" }]
+  "references": [{ "path": "../../packages/bots" }, { "path": "../../packages/engine" }]
 }

--- a/packages/bots/src/heuristic.ts
+++ b/packages/bots/src/heuristic.ts
@@ -27,7 +27,7 @@
  * the same action — essential for stable tests and replays.
  */
 
-import type { Action } from '@holdem/engine'
+import type { Action, Card } from '@holdem/engine'
 import { callIsProfitable, evOfCall, potOdds } from '@holdem/odds'
 
 import type { DecisionContext } from './context.js'
@@ -55,6 +55,19 @@ function clampToLegal(intended: number, min: number, max: number): number | null
   if (min > max) return null
   const rounded = Math.round(intended)
   return Math.min(max, Math.max(min, rounded))
+}
+
+/**
+ * Derive a per-decision Monte-Carlo seed by folding the board into the bot's base seed with
+ * an FNV-style multiply-mix. Cards are branded integers, so this is a cheap, order-sensitive
+ * hash: the same `(base, board)` always yields the same seed (determinism preserved), but
+ * preflop / flop / turn / river each get a *different* seed, so the reads across a hand draw
+ * independent samples instead of reusing one correlated stream.
+ */
+function seedForBoard(base: number, board: readonly Card[]): number {
+  let s = base | 0
+  for (const card of board) s = (Math.imul(s, 0x01000193) + card) | 0
+  return s >>> 0
 }
 
 /**
@@ -89,7 +102,12 @@ export class HeuristicOpponent implements Opponent {
   private readonly personality: Personality
   /** The bot's own PRNG, advanced once per aggression decision. Seeded for determinism. */
   private readonly rng: () => number
-  /** The fixed seed handed to every {@link estimateEquity} call, so the read is stable. */
+  /**
+   * The bot's base equity seed. Per-decision, this is mixed with the current board (via
+   * {@link seedForBoard}) so each street draws an *independent* Monte-Carlo stream rather
+   * than reusing the preflop one — while staying fully deterministic for a fixed
+   * `(seed, board)`, so tests and replays remain stable.
+   */
   private readonly equitySeed: number
 
   constructor(personality: Personality = DEFAULT_PERSONALITY, seed = 0) {
@@ -109,7 +127,7 @@ export class HeuristicOpponent implements Opponent {
       holeCards: ctx.holeCards,
       board: ctx.board,
       opponentRange: this.personality.tightness.assumedVillainRange,
-      seed: this.equitySeed,
+      seed: seedForBoard(this.equitySeed, ctx.board),
       iterations: HEURISTIC_ITERATIONS,
     }).equity
   }

--- a/packages/bots/src/opponent.ts
+++ b/packages/bots/src/opponent.ts
@@ -22,6 +22,7 @@
  */
 
 import type { Action } from '@holdem/engine'
+import { mulberry32 } from '@holdem/odds'
 
 import type { DecisionContext } from './context.js'
 
@@ -46,9 +47,10 @@ export interface Opponent {
 }
 
 /**
- * The placeholder opponent ported from the CLI's `alwaysCallBot`: it never folds and
- * never raises — it checks when checking is free and otherwise calls. (`legalActions`
- * caps the call amount at the stack, so a call here is an all-in when the bot is short.)
+ * The classic "calling station": it never folds and never raises — it checks when
+ * checking is free and otherwise calls. (`legalActions` caps the call amount at the stack,
+ * so a call here is an all-in when the bot is short.) This is the bots-package home of the
+ * trivial opponent the CLI play harness used before it adopted {@link HeuristicOpponent}.
  *
  * Useful as a passive baseline and as a "station" to test value betting against.
  */
@@ -84,23 +86,16 @@ export const rock: Opponent = {
 }
 
 /**
- * A tiny, well-known 32-bit PRNG (mulberry32): one multiply-xor-shift round per call,
- * returning a float in `[0, 1)`. Inlined here (rather than importing `@holdem/odds`) to
- * keep this package's dependency footprint to `@holdem/engine` only — the seeded bot is
- * the sole consumer and needs nothing more.
+ * The seeded 32-bit PRNG the bots use, re-exported from `@holdem/odds` (its canonical
+ * home, where the equity sampler already uses it). `@holdem/bots` depends on `@holdem/odds`
+ * anyway — for the equity reads in {@link estimateEquity} — so there is no footprint to
+ * save by re-implementing it here; sharing the one definition keeps every "same seed ⇒
+ * identical sequence" guarantee in the project pointing at a single source of truth.
  *
- * Same seed ⇒ identical sequence, so a {@link randomBot} is fully reproducible in tests.
+ * Re-exported (not just imported) because the seeded bots below and {@link HeuristicOpponent}
+ * are its consumers and tests reach for it directly.
  */
-export function mulberry32(seed: number): () => number {
-  let a = seed >>> 0
-  return () => {
-    a |= 0
-    a = (a + 0x6d2b79f5) | 0
-    let t = Math.imul(a ^ (a >>> 15), 1 | a)
-    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
-  }
-}
+export { mulberry32 }
 
 /**
  * A seeded-random opponent that uniformly picks among its **currently legal** simple

--- a/packages/odds/src/equity.test.ts
+++ b/packages/odds/src/equity.test.ts
@@ -8,11 +8,15 @@ function totalEquity(req: EquityRequest): number {
 }
 
 // Full preflop enumeration (an empty board) is the heavyweight case: heads-up it scores
-// C(48,5) = 1,712,304 board completions. It is exact and reproducible but takes seconds,
+// C(48,5) = 1,712,304 board completions. It is exact and reproducible but takes ~20s locally,
 // so the suite runs exactly one such spot — the AA-vs-KK acceptance criterion — under a
 // generous timeout. Every other spot uses a partial board (flop/turn), which enumerates
 // in well under a millisecond, to keep the suite fast while still exercising every path.
-const PREFLOP_TIMEOUT_MS = 60_000
+//
+// The timeout is sized for CI, not this machine: there the test runs under v8 coverage
+// instrumentation on a contended 2-core runner, several times slower than a local run, so
+// it needs far more headroom than the bare ~20s it takes here.
+const PREFLOP_TIMEOUT_MS = 180_000
 
 describe('exactEquity — textbook spots', () => {
   it(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
 
   apps/cli:
     dependencies:
+      '@holdem/bots':
+        specifier: workspace:*
+        version: link:../../packages/bots
       '@holdem/engine':
         specifier: workspace:*
         version: link:../../packages/engine

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,13 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     include: ['packages/**/src/**/*.test.ts', 'apps/**/src/**/*.test.ts'],
+    // A few correctness oracles are deliberately exhaustive — the full C(52,5) hand-frequency
+    // sweep and the multi-seed bot loops run in ~1s locally. But CI runs them under v8 coverage
+    // instrumentation on a 2-core runner with every test file contending, which is several times
+    // slower, so the stock 5s per-test timeout trips them. Raise the global floor well past that;
+    // the single heaviest spot (exact preflop enumeration) sets its own larger timeout inline.
+    testTimeout: 60_000,
+    hookTimeout: 60_000,
     coverage: {
       provider: 'v8',
       // The pure, correctness-critical packages every later milestone trusts — the engine


### PR DESCRIPTION
## What

Fixes the red CI on `main` and addresses the three findings from the M2 milestone review.

### CI failure (root cause: test timeouts under coverage on slow CI cores)
CI has been red since M1. The failures were **timeouts, not assertion failures** — the exhaustive correctness oracles (full `C(52,5)` hand-frequency sweep, exact AA-vs-KK preflop enumeration of 1.7M boards, multi-seed bot loops) pass in ~1s locally but on GitHub run under v8 coverage instrumentation on a contended 2-core runner, several times slower, tripping the stock 5s per-test timeout (and the preflop spot's own 60s).

- `vitest.config.ts`: global `testTimeout`/`hookTimeout` → 60s.
- `equity.test.ts`: the one heavyweight preflop spot → 180s, sized for CI-under-coverage.

### Review findings
- **[MEDIUM] Duplicated `mulberry32` PRNG with a false justification** — `bots` inlined its own copy "to keep the dep footprint to `@holdem/engine` only", but `bots` already depends on `@holdem/odds` (mulberry32's canonical home). Now re-exported from `@holdem/odds` so every "same seed ⇒ same sequence" guarantee has one source of truth.
- **[LOW] CLI stub bot** — wired the `pnpm play` harness through `@holdem/bots` (`HeuristicOpponent` via the `decisionContext` seam) and deleted the duplicate local `alwaysCallBot`. M2's bot is now actually playable, and there's no stub to forget at M4.
- **[LOW] Reused equity seed across streets** — the heuristic bot now mixes the board into a per-decision seed, so each street draws an independent sample stream (still deterministic for a fixed seed+board).

## Verification
- `pnpm verify` green locally: 209 tests pass (was 211; removed 2 `alwaysCallBot` tests), coverage above gate.
- CLI smoke-tested end-to-end: the TAG bot folds, checks, and bets legally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)