### PR TITLE
fix(ci): let slow bot-loop tests inherit the global timeout floor

### DIFF
--- a/packages/bots/src/heuristic.test.ts
+++ b/packages/bots/src/heuristic.test.ts
@@ -372,6 +372,11 @@ describe('HeuristicOpponent — determinism', () => {
   })
 })
 
+// These multi-seed self-play loops run a seeded Monte-Carlo equity read per decision, so they are
+// the slow tests the global `testTimeout` floor in vitest.config.ts was deliberately raised "well
+// past" 5s to cover. They therefore inherit that floor rather than pinning their own inline timeout
+// — an inline value below the floor (the old `30000`) silently shrank the budget under it and
+// tripped on the loaded 2-core CI runner under coverage instrumentation.
 describe('HeuristicOpponent — robustness: full hands run to completion legally', () => {
   function buildDeck(n: number, button: number, holesBySeat: string[], board: string): Card[] {
     const sbIndex = n === 2 ? button : (button + 1) % n
@@ -402,7 +407,7 @@ describe('HeuristicOpponent — robustness: full hands run to completion legally
       })
       expect(final.street).toBe('complete')
     }
-  }, 30000)
+  })
 
   it('HeuristicOpponent vs a reference bot completes across many seeds', async () => {
     const refs: Opponent[] = [callingStation, rock]
@@ -414,7 +419,7 @@ describe('HeuristicOpponent — robustness: full hands run to completion legally
       })
       expect(final.street).toBe('complete')
     }
-  }, 30000)
+  })
 
   it('all four personalities complete a self-play hand across seeds', async () => {
     const personalities = [TIGHT_AGGRESSIVE, LOOSE_AGGRESSIVE, TIGHT_PASSIVE, LOOSE_PASSIVE]
@@ -427,5 +432,5 @@ describe('HeuristicOpponent — robustness: full hands run to completion legally
         expect(final.street).toBe('complete')
       }
     }
-  }, 30000)
+  })
 })


### PR DESCRIPTION
## What

`main` CI went red on the M3.5-planning merge: the bots test
`HeuristicOpponent vs HeuristicOpponent completes across many seeds`
hit `Test timed out in 30000ms`.

## Why

The three multi-seed `HeuristicOpponent` self-play loops each pinned an
inline `30000`ms timeout. But `vitest.config.ts` deliberately raises the
**global** `testTimeout` floor to 60s "well past" the stock 5s precisely
to cover these loops (each runs a seeded Monte-Carlo equity read per
decision). The inline `30000` *shrank* the budget below that floor, so
under v8 coverage instrumentation on a 2-core CI runner the heaviest loop
(LAG vs TP, 60 seeds) tripped at 30s — even though it runs in ~1–14s
locally.

## Fix

Drop the inline overrides so the loops inherit the 60s floor that was
raised for them, plus a comment so the floor isn't undercut again. No
test logic changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)