### PR TITLE
Decode poker shorthand + Learn/action-bar UI fixes

### DIFF
--- a/apps/pwa/src/App.nav.test.tsx
+++ b/apps/pwa/src/App.nav.test.tsx
@@ -11,6 +11,7 @@ import { cleanup, fireEvent, render, screen, within } from '@testing-library/rea
 import { afterEach, describe, expect, it } from 'vitest'
 import { FOUNDATIONS } from '@holdem/curriculum'
 import { App } from './App.js'
+import { lessonHead } from './learn/lessonMeta.js'
 
 afterEach(cleanup)
 
@@ -35,10 +36,11 @@ describe('App — top-level navigation', () => {
     fireEvent.click(screen.getByTestId('tab-learn'))
 
     expect(screen.getByTestId('learn')).toBeTruthy()
-    // One node per lesson, each carrying its title (the node's h3 starts with the lesson title).
+    // One node per lesson, each carrying its title *head* (the concept name before the colon) — the
+    // qualifier after the colon is the subtitle, shown once, not the full title repeated.
     for (let i = 0; i < FOUNDATIONS.length; i++) {
       const node = within(screen.getByTestId(`node-${i}`))
-      expect(node.getByRole('heading').textContent).toContain(FOUNDATIONS[i]!.title)
+      expect(node.getByRole('heading').textContent).toContain(lessonHead(FOUNDATIONS[i]!))
     }
   })
 

--- a/apps/pwa/src/components/ChartOverlay.test.tsx
+++ b/apps/pwa/src/components/ChartOverlay.test.tsx
@@ -47,4 +47,24 @@ describe('ChartOverlay', () => {
     fireEvent.keyDown(window, { key: 'Escape' })
     expect(onClose).toHaveBeenCalledTimes(3)
   })
+
+  it('prompts for a tap, then decodes the tapped hand in the caption', () => {
+    render(<ChartOverlay onClose={vi.fn()} />)
+    const caption = screen.getByTestId('chart-caption')
+    // Nothing selected yet — a hint invites the first tap.
+    expect(caption.textContent).toMatch(/Tap any hand/i)
+
+    // Tapping JTo decodes it in words with its tier.
+    fireEvent.click(screen.getByTitle(/^JTo —/))
+    expect(caption.textContent).toContain('JTo')
+    expect(caption.textContent).toContain('Jack-Ten offsuit')
+    expect(caption.textContent).toContain('Marginal')
+  })
+
+  it('seeds the caption with the highlighted hand so the decode shows on open', () => {
+    render(<ChartOverlay onClose={vi.fn()} highlight="AKs" />)
+    const caption = screen.getByTestId('chart-caption')
+    expect(caption.textContent).toContain('AKs')
+    expect(caption.textContent).toContain('Ace-King suited')
+  })
 })

--- a/apps/pwa/src/components/ChartOverlay.tsx
+++ b/apps/pwa/src/components/ChartOverlay.tsx
@@ -14,9 +14,9 @@
  * a labelled `role="dialog"`, focus moved to the close button on open, Escape to close, focus restored.
  */
 
-import { useEffect, useMemo, useRef } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
-import { startingHandChart, type PreflopTier } from '@holdem/coach'
+import { describeHandClass, startingHandChart, type PreflopTier } from '@holdem/coach'
 
 /** The tiers in strength order — the legend order, strongest first. */
 const TIER_ORDER: readonly PreflopTier[] = ['premium', 'strong', 'playable', 'marginal', 'trash']
@@ -47,6 +47,15 @@ export function ChartOverlay({ onClose, highlight }: ChartOverlayProps): React.J
   const closeRef = useRef<HTMLButtonElement>(null)
   // The grid is a pure function of nothing (the chart is fixed), so compute it once per open.
   const grid = useMemo(() => startingHandChart(), [])
+  // Tap-to-decode: the selected cell's label drives the caption that spells the shorthand out in
+  // words — the touch-friendly counterpart to the hover `title` (which never fires on a phone). Seed
+  // it with "your hand" when the coach opened the chart, so the decode is already showing on open.
+  const [selected, setSelected] = useState<string | undefined>(highlight)
+  // The tier of the selected cell, for the caption's "— Marginal" suffix (cells carry their tier).
+  const selectedTier = useMemo(
+    () => grid.flat().find((cell) => cell.label === selected)?.tier,
+    [grid, selected],
+  )
 
   // Focus management (mirrors CoachDrawer): focus the close button on open, Escape closes, restore
   // focus to the opener on unmount. The overlay mounts only while open, so this runs once per open.
@@ -107,19 +116,42 @@ export function ChartOverlay({ onClose, highlight }: ChartOverlayProps): React.J
           {grid.flatMap((row, r) =>
             row.map((cell, c) => {
               const current = highlight !== undefined && cell.label === highlight
+              const isSelected = cell.label === selected
+              const decoded = describeHandClass(cell.label)
               return (
-                <div
+                <button
+                  type="button"
                   key={`${r}-${c}`}
-                  className={`chart-cell tier-${cell.tier}${current ? ' is-current' : ''}`}
-                  title={`${cell.label} — ${TIER_LABEL[cell.tier]}${current ? ' (your hand)' : ''}`}
+                  className={
+                    `chart-cell tier-${cell.tier}` +
+                    (current ? ' is-current' : '') +
+                    (isSelected ? ' is-selected' : '')
+                  }
+                  onClick={() => setSelected(cell.label)}
+                  title={`${cell.label} — ${decoded} — ${TIER_LABEL[cell.tier]}${current ? ' (your hand)' : ''}`}
+                  aria-label={`${decoded}, ${TIER_LABEL[cell.tier]}${current ? ', your hand' : ''}`}
+                  aria-pressed={isSelected}
                   data-testid={current ? 'chart-current' : undefined}
                 >
                   {cell.label}
-                </div>
+                </button>
               )
             }),
           )}
         </div>
+
+        {/* Decode caption: spells the tapped cell's shorthand out in words. aria-live so a screen
+            reader announces the decode when selection changes; a hint prompts the first tap. */}
+        <p className="chart-caption" data-testid="chart-caption" aria-live="polite">
+          {selected && selectedTier ? (
+            <>
+              <b className="chart-your-hand">{selected}</b> — {describeHandClass(selected)} —{' '}
+              {TIER_LABEL[selectedTier]}
+            </>
+          ) : (
+            <span className="chart-caption-hint">Tap any hand to read its full name.</span>
+          )}
+        </p>
 
         <div className="chart-legend" data-testid="chart-legend">
           {TIER_ORDER.map((tier) => (

--- a/apps/pwa/src/components/GlossaryOverlay.test.tsx
+++ b/apps/pwa/src/components/GlossaryOverlay.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+/**
+ * GlossaryOverlay component test: the poker-shorthand reference renders its decoded sections, keeps
+ * its hand-class meanings in lock-step with `@holdem/coach`'s `describeHandClass`, and dismisses via
+ * the close button, the scrim, and Escape (the shared overlay a11y bar). Presentational — no state.
+ */
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { describeHandClass } from '@holdem/coach'
+import { GlossaryOverlay } from './GlossaryOverlay.js'
+
+afterEach(cleanup)
+
+describe('GlossaryOverlay', () => {
+  it('renders the dialog with the shorthand sections', () => {
+    render(<GlossaryOverlay onClose={vi.fn()} />)
+    const dialog = screen.getByTestId('glossary-modal')
+    expect(dialog.getAttribute('role')).toBe('dialog')
+    for (const title of ['Starting hands', 'Strength tiers', 'Table positions', 'Cards']) {
+      expect(screen.getByText(title)).toBeTruthy()
+    }
+  })
+
+  it('decodes hand-class shorthand through the same coach helper as the chart', () => {
+    render(<GlossaryOverlay onClose={vi.fn()} />)
+    const body = screen.getByTestId('glossary-body')
+    // The meaning text is sourced from describeHandClass, so it cannot drift from the chart caption.
+    expect(body.textContent).toContain(describeHandClass('JTo')) // 'Jack-Ten offsuit'
+    expect(body.textContent).toContain(describeHandClass('AKs')) // 'Ace-King suited'
+    expect(body.textContent).toContain(describeHandClass('AA')) // 'pair of Aces'
+  })
+
+  it('explains the position tags shown on the felt', () => {
+    render(<GlossaryOverlay onClose={vi.fn()} />)
+    const body = screen.getByTestId('glossary-body')
+    for (const tag of ['BTN', 'SB', 'BB']) {
+      expect(body.textContent).toContain(tag)
+    }
+  })
+
+  it('closes via the close button, the scrim, and Escape', () => {
+    const onClose = vi.fn()
+    render(<GlossaryOverlay onClose={onClose} />)
+    fireEvent.click(screen.getByTestId('glossary-close'))
+    fireEvent.click(screen.getByTestId('glossary-scrim'))
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledTimes(3)
+  })
+})

--- a/apps/pwa/src/components/GlossaryOverlay.tsx
+++ b/apps/pwa/src/components/GlossaryOverlay.tsx
@@ -1,0 +1,159 @@
+/**
+ * The **poker-shorthand glossary** overlay — a one-stop decode for the terse notation the app uses
+ * everywhere a learner meets it: the starting-hand chart cells (`JTo`), the coach drawer's "your hand"
+ * highlight, the seat tags on the felt (`BTN`/`SB`/`BB`), and the card faces. The chart's tap-to-decode
+ * caption answers "what is *this* hand"; this answers "what does the *notation* mean" once, for the
+ * whole system.
+ *
+ * Presentational only and self-contained: a centred modal over its own scrim, opened from the Learn
+ * header next to the chart link. The hand-class examples are read through `@holdem/coach`'s
+ * {@link describeHandClass}, so the glossary can never disagree with the chart caption it explains.
+ * Accessibility mirrors {@link ChartOverlay}: a labelled `role="dialog"`, focus moved to the close
+ * button on open, Escape to close, focus restored to the opener.
+ */
+
+import { useEffect, useRef } from 'react'
+import { createPortal } from 'react-dom'
+import { describeHandClass } from '@holdem/coach'
+
+/** One decoded term: the shorthand as written, and what it means in plain English. */
+interface GlossaryEntry {
+  /** The shorthand token exactly as it appears in the UI, e.g. `"AKs"`, `"BTN"`, `"A♥"`. */
+  readonly term: string
+  /** Its plain-English meaning. */
+  readonly meaning: string
+}
+
+/** A titled group of related shorthand, with an optional one-line lead-in. */
+interface GlossarySection {
+  readonly title: string
+  readonly intro?: string
+  readonly entries: readonly GlossaryEntry[]
+}
+
+/**
+ * The glossary content. Hand-class meanings come from {@link describeHandClass} so they stay in lock-step
+ * with the chart's decode caption; the rest is the notation the live table and lessons render.
+ */
+const SECTIONS: readonly GlossarySection[] = [
+  {
+    title: 'Starting hands',
+    intro: 'How two cards are written. The higher rank comes first; T means Ten.',
+    entries: [
+      { term: 'AA', meaning: `${describeHandClass('AA')} — two cards of the same rank` },
+      { term: 'AKs', meaning: `${describeHandClass('AKs')} — same suit ("s")` },
+      { term: 'JTo', meaning: `${describeHandClass('JTo')} — different suits ("o")` },
+    ],
+  },
+  {
+    title: 'Strength tiers',
+    intro: 'The colour buckets on the chart — strongest to weakest.',
+    entries: [
+      { term: 'Premium', meaning: 'The best hands — always raise.' },
+      { term: 'Strong', meaning: 'Clear value — open and bet.' },
+      { term: 'Playable', meaning: 'Speculative — open in position with a plan.' },
+      { term: 'Marginal', meaning: 'Thin — open only late; fold to pressure.' },
+      { term: 'Trash', meaning: 'Folds — makes no money over time.' },
+    ],
+  },
+  {
+    title: 'Table positions',
+    intro: 'The tags beside the seats. Position decides how early you must act.',
+    entries: [
+      { term: 'BTN', meaning: 'Button — the dealer; acts last after the flop (best seat).' },
+      { term: 'SB', meaning: 'Small blind — a forced bet to the button’s left.' },
+      { term: 'BB', meaning: 'Big blind — the larger forced bet; acts last preflop.' },
+    ],
+  },
+  {
+    title: 'Cards',
+    intro: 'A card is a rank plus a suit.',
+    entries: [
+      { term: '♠ ♥ ♦ ♣', meaning: 'Spades, hearts, diamonds, clubs.' },
+      { term: 'A K Q J T', meaning: 'Ace, King, Queen, Jack, Ten — then 9 down to 2.' },
+      { term: 'A♥', meaning: 'The Ace of hearts (rank, then suit).' },
+    ],
+  },
+]
+
+/** Props for {@link GlossaryOverlay}. */
+export interface GlossaryOverlayProps {
+  /** Dismiss the overlay. */
+  readonly onClose: () => void
+}
+
+/** Render the poker-shorthand glossary as a centred modal over a scrim. */
+export function GlossaryOverlay({ onClose }: GlossaryOverlayProps): React.JSX.Element {
+  const closeRef = useRef<HTMLButtonElement>(null)
+
+  // Focus management (mirrors ChartOverlay): focus the close button on open, Escape closes, restore
+  // focus to the opener on unmount. The overlay mounts only while open, so this runs once per open.
+  useEffect(() => {
+    const opener = document.activeElement as HTMLElement | null
+    closeRef.current?.focus()
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => {
+      window.removeEventListener('keydown', onKey)
+      opener?.focus?.()
+    }
+  }, [onClose])
+
+  // Portal to <body> so the overlay escapes any transformed ancestor and centres on the viewport
+  // (same reasoning as ChartOverlay / BUG-0006).
+  return createPortal(
+    <>
+      <div
+        className="chart-scrim"
+        onClick={onClose}
+        aria-hidden="true"
+        data-testid="glossary-scrim"
+      />
+      <div
+        className="chart-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Poker shorthand"
+        data-testid="glossary-modal"
+      >
+        <div className="drawer-head">
+          <div className="drawer-title">Poker shorthand</div>
+          <button
+            type="button"
+            className="drawer-close"
+            ref={closeRef}
+            onClick={onClose}
+            aria-label="Close glossary"
+            data-testid="glossary-close"
+          >
+            ×
+          </button>
+        </div>
+
+        <p className="chart-note">
+          The terse notation the chart, coach, and table use — decoded once, in plain English.
+        </p>
+
+        <div className="glossary" data-testid="glossary-body">
+          {SECTIONS.map((section) => (
+            <section className="glossary-section" key={section.title}>
+              <h3 className="glossary-title">{section.title}</h3>
+              {section.intro ? <p className="glossary-intro">{section.intro}</p> : null}
+              <dl className="glossary-list">
+                {section.entries.map((entry) => (
+                  <div className="glossary-row" key={entry.term}>
+                    <dt className="glossary-term">{entry.term}</dt>
+                    <dd className="glossary-meaning">{entry.meaning}</dd>
+                  </div>
+                ))}
+              </dl>
+            </section>
+          ))}
+        </div>
+      </div>
+    </>,
+    document.body,
+  )
+}

--- a/apps/pwa/src/components/LearnView.tsx
+++ b/apps/pwa/src/components/LearnView.tsx
@@ -15,7 +15,7 @@
  */
 
 import { useState } from 'react'
-import { learnLessons } from '../learn/lessonMeta.js'
+import { learnLessons, lessonHead } from '../learn/lessonMeta.js'
 import { ChartOverlay } from './ChartOverlay.js'
 import { GlossaryOverlay } from './GlossaryOverlay.js'
 import { CheckIcon, ChevIcon, LockIcon } from './Icons.js'
@@ -153,7 +153,7 @@ export function LearnView({
                   <div className="node-label">
                     <div className="nl-tier">Lesson {n}</div>
                     <h3>
-                      {lesson.title}
+                      {lessonHead(lesson)}
                       {meta.subtitle ? ` · ${meta.subtitle}` : ''}
                     </h3>
                     <p>{meta.teaser}</p>

--- a/apps/pwa/src/components/LearnView.tsx
+++ b/apps/pwa/src/components/LearnView.tsx
@@ -17,6 +17,7 @@
 import { useState } from 'react'
 import { learnLessons } from '../learn/lessonMeta.js'
 import { ChartOverlay } from './ChartOverlay.js'
+import { GlossaryOverlay } from './GlossaryOverlay.js'
 import { CheckIcon, ChevIcon, LockIcon } from './Icons.js'
 import { TabBar } from './TabBar.js'
 import type { Tab } from './TabBar.js'
@@ -46,6 +47,8 @@ export function LearnView({
   const count = lessons.length
   // The starting-hand chart reference is a self-contained overlay; its open state is local UI.
   const [chartOpen, setChartOpen] = useState(false)
+  // The poker-shorthand glossary is a sibling reference overlay — same local-UI open state.
+  const [glossaryOpen, setGlossaryOpen] = useState(false)
   // The current node is the first unfinished lesson (clamped); once all are done the path is "all done".
   const allDone = progress >= count
   const currentIdx = Math.min(progress, count - 1)
@@ -80,14 +83,24 @@ export function LearnView({
                 {progress} / {count}
               </div>
             </div>
-            <button
-              type="button"
-              className="chart-link"
-              data-testid="open-chart"
-              onClick={() => setChartOpen(true)}
-            >
-              ♠ View the starting-hand chart
-            </button>
+            <div className="learn-refs">
+              <button
+                type="button"
+                className="chart-link"
+                data-testid="open-chart"
+                onClick={() => setChartOpen(true)}
+              >
+                ♠ View the starting-hand chart
+              </button>
+              <button
+                type="button"
+                className="chart-link"
+                data-testid="open-glossary"
+                onClick={() => setGlossaryOpen(true)}
+              >
+                🔤 Decode poker shorthand
+              </button>
+            </div>
           </div>
 
           <div className="path" style={{ height: count * ROW_H + 8 }}>
@@ -180,6 +193,7 @@ export function LearnView({
       <TabBar active="learn" onNavigate={onNavigate} />
 
       {chartOpen ? <ChartOverlay onClose={() => setChartOpen(false)} /> : null}
+      {glossaryOpen ? <GlossaryOverlay onClose={() => setGlossaryOpen(false)} /> : null}
     </div>
   )
 }

--- a/apps/pwa/src/components/LessonPlayer.tsx
+++ b/apps/pwa/src/components/LessonPlayer.tsx
@@ -35,7 +35,7 @@ import {
   type SpotVerdict,
 } from '@holdem/curriculum'
 import { explainDecision, pct, signedChips, VERDICT_LABEL } from '@holdem/format'
-import { lessonMeta, positionLabel } from '../learn/lessonMeta.js'
+import { lessonHead, lessonMeta, positionLabel } from '../learn/lessonMeta.js'
 import { Card } from './Card.js'
 import { BackIcon, SparkIcon } from './Icons.js'
 import { SeatRing } from './SeatRing.js'
@@ -202,7 +202,7 @@ function ReadView({
 }): React.JSX.Element {
   const meta = lessonMeta(lesson)
   // The package title is "Equity: your share of the pot"; show just the head, with the subtitle below.
-  const head = lesson.title.split(':')[0] ?? lesson.title
+  const head = lessonHead(lesson)
   const startLabel = lesson.spots.length > 1 ? 'Start the checks →' : 'Start the check →'
   return (
     <>

--- a/apps/pwa/src/learn/lessonMeta.test.ts
+++ b/apps/pwa/src/learn/lessonMeta.test.ts
@@ -1,0 +1,41 @@
+/**
+ * lessonMeta test: the title/subtitle split that the Learn path and the lesson read view share.
+ * Guards the regression where the path rendered the full title *plus* the subtitle and so repeated
+ * the qualifier ("Equity: your share of the pot · your share of the pot").
+ */
+
+import { describe, expect, it } from 'vitest'
+import { FOUNDATIONS } from '@holdem/curriculum'
+import { learnLessons, lessonHead, lessonMeta } from './lessonMeta.js'
+
+describe('lessonHead', () => {
+  it('returns the concept name before the colon', () => {
+    const equity = FOUNDATIONS.find((l) => l.id === 'foundations-equity')!
+    expect(equity.title).toBe('Equity: your share of the pot')
+    expect(lessonHead(equity)).toBe('Equity')
+  })
+
+  it('returns the whole title when there is no colon', () => {
+    expect(lessonHead({ ...FOUNDATIONS[0]!, title: 'No colon here' })).toBe('No colon here')
+  })
+
+  it('never repeats the subtitle — "head · subtitle" carries no duplicate phrase', () => {
+    // The bug: rendering `${title} · ${subtitle}` repeated the part after the colon. With the head,
+    // the qualifier appears exactly once across the whole "head · subtitle" line.
+    for (const { lesson, meta } of learnLessons) {
+      const line = meta.subtitle ? `${lessonHead(lesson)} · ${meta.subtitle}` : lessonHead(lesson)
+      if (meta.subtitle) {
+        const occurrences = line.split(meta.subtitle).length - 1
+        expect(occurrences).toBe(1)
+      }
+    }
+  })
+
+  it('agrees with the design copy: each subtitle is exactly the title tail after the colon', () => {
+    // Confirms the split is the right seam — the package title is "head: subtitle" verbatim.
+    for (const lesson of FOUNDATIONS) {
+      const { subtitle } = lessonMeta(lesson)
+      if (subtitle) expect(lesson.title).toBe(`${lessonHead(lesson)}: ${subtitle}`)
+    }
+  })
+})

--- a/apps/pwa/src/learn/lessonMeta.ts
+++ b/apps/pwa/src/learn/lessonMeta.ts
@@ -66,6 +66,16 @@ export function lessonMeta(lesson: Lesson): LessonMeta {
   return LESSON_META[lesson.id] ?? EMPTY_META
 }
 
+/**
+ * The **head** of a lesson title — the concept name before the colon (`"Equity: your share of the
+ * pot"` → `"Equity"`). The bit after the colon is the {@link LessonMeta.subtitle}, shown separately,
+ * so a view that renders `head · subtitle` (the path) or `head` over `subtitle` (the read view) never
+ * repeats the qualifier. Returns the whole title unchanged when there is no colon.
+ */
+export function lessonHead(lesson: Lesson): string {
+  return lesson.title.split(':')[0] ?? lesson.title
+}
+
 /** A lesson zipped with its display copy and its 1-based position — what the Learn path renders over. */
 export interface LearnLesson {
   /** The pure content lesson from `@holdem/curriculum`. */

--- a/apps/pwa/src/primer.css
+++ b/apps/pwa/src/primer.css
@@ -1204,8 +1204,12 @@
 }
 .chart-cell {
   aspect-ratio: 1;
+  width: 100%;
   display: grid;
   place-items: center;
+  border: 0;
+  padding: 0;
+  margin: 0;
   border-radius: 3px;
   font-family: var(--font-mono);
   font-size: 8px;
@@ -1214,6 +1218,41 @@
   color: var(--text-2);
   background: var(--surface-2);
   overflow: hidden;
+  cursor: pointer;
+  -webkit-appearance: none;
+  appearance: none;
+  transition: outline-color 0.1s;
+}
+.chart-cell:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -1px;
+  z-index: 2;
+}
+/* the tapped cell — a soft accent ring (distinct from the bright "your hand" ring) that drives the
+   decode caption below the grid. Works on touch, where the hover `title` never fires. */
+.chart-cell.is-selected {
+  outline: 2px solid var(--accent);
+  outline-offset: -1px;
+  position: relative;
+  z-index: 1;
+  font-weight: 800;
+}
+
+/* decode caption: the tapped cell's shorthand read aloud in words ("JTo — Jack-Ten offsuit — Marginal") */
+.chart-caption {
+  margin: 12px 0 0;
+  min-height: 1.2em;
+  font-size: 13px;
+  line-height: 1.4;
+  color: var(--text);
+  text-align: center;
+}
+.chart-caption .chart-your-hand {
+  font-weight: 700;
+}
+.chart-caption-hint {
+  color: var(--text-3);
+  font-style: italic;
 }
 
 /* tier scale: a green heat ramp by lightness (premium brightest → playable dim, all at the accent's
@@ -1282,6 +1321,63 @@
 .chart-link:hover {
   border-color: var(--accent);
   color: var(--accent);
+}
+
+/* the Learn header's reference buttons (chart + shorthand glossary) wrap onto two rows on narrow phones */
+.learn-refs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+/* poker-shorthand glossary (reuses .chart-modal / .chart-scrim / .chart-note for the shell) */
+.glossary {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+.glossary-section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.glossary-title {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: var(--accent);
+}
+.glossary-intro {
+  margin: 0;
+  font-size: 12.5px;
+  line-height: 1.4;
+  color: var(--text-2);
+}
+.glossary-list {
+  margin: 2px 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+.glossary-row {
+  display: grid;
+  grid-template-columns: 72px 1fr;
+  gap: 12px;
+  align-items: baseline;
+}
+.glossary-term {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text);
+  text-align: right;
+}
+.glossary-meaning {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.4;
+  color: var(--text-2);
 }
 
 /* "your hand" highlight in the chart (BUG-0006 / ticket 0050): a bright ring that reads on any tier

--- a/apps/pwa/src/styles.css
+++ b/apps/pwa/src/styles.css
@@ -611,6 +611,13 @@ body {
   padding: 10px 14px calc(12px + env(safe-area-inset-bottom));
   display: flex;
   flex-direction: column;
+  /* Anchor the controls to the bottom and reserve the hero-turn height for every state, so the bar
+     never grows/shrinks as the turn passes (bet-row appears, buttons gain their amount line). The
+     floor is the measured tallest layout — bet-row + a two-line actions row + padding — plus the
+     safe-area inset the padding also carries; shorter states (a bot's "Waiting…", the between-hands
+     CTAs) fill the reserved space above the buttons instead of collapsing and shifting the table. */
+  justify-content: flex-end;
+  min-height: calc(140px + env(safe-area-inset-bottom));
   gap: 9px;
   background: linear-gradient(0deg, var(--bg), var(--bg) 70%, transparent);
 }

--- a/packages/coach/src/preflop.test.ts
+++ b/packages/coach/src/preflop.test.ts
@@ -4,6 +4,7 @@ import type { DecisionContext } from '@holdem/bots'
 
 import {
   classifyStartingHand,
+  describeHandClass,
   gradePreflop,
   PREFLOP_CHART,
   CHART_RANKS,
@@ -382,5 +383,45 @@ describe('handClassLabel', () => {
     for (const cards of ['AsAh', 'AhKh', 'AhKs', '7c2d', 'Th9h', 'Js9c', 'Qd2d']) {
       expect(cellLabels.has(handClassLabel(hole(cards)))).toBe(true)
     }
+  })
+})
+
+describe('describeHandClass', () => {
+  it('decodes pairs as "pair of <plural rank>"', () => {
+    expect(describeHandClass('AA')).toBe('pair of Aces')
+    expect(describeHandClass('KK')).toBe('pair of Kings')
+    expect(describeHandClass('TT')).toBe('pair of Tens')
+    expect(describeHandClass('22')).toBe('pair of Twos')
+  })
+
+  it('uses the irregular plural for pocket sixes', () => {
+    expect(describeHandClass('66')).toBe('pair of Sixes')
+  })
+
+  it('decodes suited and offsuit hands with the rank words and "suited"/"offsuit"', () => {
+    expect(describeHandClass('AKs')).toBe('Ace-King suited')
+    expect(describeHandClass('JTo')).toBe('Jack-Ten offsuit')
+    expect(describeHandClass('T9s')).toBe('Ten-Nine suited')
+    expect(describeHandClass('72o')).toBe('Seven-Two offsuit')
+  })
+
+  it('decodes every label the chart renders (no cell reads as raw shorthand)', () => {
+    for (const cell of startingHandChart().flat()) {
+      const decoded = describeHandClass(cell.label)
+      // A decoded label is real prose, never the bare token echoed back.
+      expect(decoded).not.toBe(cell.label)
+      expect(decoded).toMatch(/pair of |suited|offsuit/)
+    }
+  })
+
+  it('round-trips with handClassLabel — a dealt hand decodes to a sensible phrase', () => {
+    expect(describeHandClass(handClassLabel(hole('AhKh')))).toBe('Ace-King suited')
+    expect(describeHandClass(handClassLabel(hole('JdTc')))).toBe('Jack-Ten offsuit')
+  })
+
+  it('returns the input unchanged for unrecognisable strings', () => {
+    expect(describeHandClass('')).toBe('')
+    expect(describeHandClass('XY')).toBe('XY')
+    expect(describeHandClass('AKx')).toBe('AKx')
   })
 })

--- a/packages/coach/src/preflop.ts
+++ b/packages/coach/src/preflop.ts
@@ -364,6 +364,56 @@ export function handClassLabel(holeCards: readonly [Card, Card]): string {
 }
 
 /**
+ * Plain-English rank words keyed by the single-character notation the chart and {@link handClassLabel}
+ * use (`A`…`2`, `T` = Ten). The spoken form of a rank, for decoding shorthand into human copy.
+ */
+const RANK_WORD: Readonly<Record<string, string>> = {
+  A: 'Ace',
+  K: 'King',
+  Q: 'Queen',
+  J: 'Jack',
+  T: 'Ten',
+  '9': 'Nine',
+  '8': 'Eight',
+  '7': 'Seven',
+  '6': 'Six',
+  '5': 'Five',
+  '4': 'Four',
+  '3': 'Three',
+  '2': 'Two',
+}
+
+/** Pluralised rank word for a pocket pair, e.g. `"Kings"`, `"Sixes"` (the one irregular plural). */
+function pluralRank(word: string): string {
+  return word === 'Six' ? 'Sixes' : `${word}s`
+}
+
+/**
+ * Decode a hand-class **label** into plain English — the spoken form of the chart's shorthand, so a
+ * UI can expand a terse `"JTo"` cell or coach highlight into words a learner can read:
+ *
+ *   describeHandClass('AA')  // 'pair of Aces'
+ *   describeHandClass('AKs') // 'Ace-King suited'
+ *   describeHandClass('JTo') // 'Jack-Ten offsuit'
+ *
+ * The human-facing companion to {@link handClassLabel}: it takes that function's exact output (and any
+ * {@link ChartCell.label}) and reads it aloud. Pure. Returns the input unchanged if it isn't a
+ * recognisable hand-class label, so callers can pass arbitrary strings without guarding.
+ */
+export function describeHandClass(label: string): string {
+  const hi = RANK_WORD[label[0] ?? '']
+  const lo = RANK_WORD[label[1] ?? '']
+  if (!hi || !lo) return label
+  // Pair: two identical ranks, no suffix ("QQ"). Plural reads as a holding ("pair of Queens").
+  if (label.length === 2 && label[0] === label[1]) return `pair of ${pluralRank(hi)}`
+  // Suited/offsuit: higher-lower plus an s/o suffix ("AKs" / "JTo").
+  if (label.length === 3 && (label[2] === 's' || label[2] === 'o')) {
+    return `${hi}-${lo} ${label[2] === 's' ? 'suited' : 'offsuit'}`
+  }
+  return label
+}
+
+/**
  * One cell of the {@link startingHandChart} grid: a starting-hand *class* (a `"AA"` / `"AKs"` /
  * `"AKo"` label and which of the three kinds it is) and the {@link PreflopTier} it classifies into.
  * A flat, serialisable value — the hand-off shape a chart view renders.


### PR DESCRIPTION
Three small player-facing improvements, each its own commit:

### 1. Decode poker shorthand (`feat`)
A pure `describeHandClass(label)` helper in `@holdem/coach` (`'JTo' → "Jack-Ten offsuit"`), used in two new places so the terse notation is decodable on a phone:
- **Chart caption** — cells are now buttons; tapping one writes its full decode under the grid (`JTo — Jack-Ten offsuit — Marginal`). Works on touch, unlike the hover `title`. Seeded with the coach's highlighted hand; announced via `aria-live`.
- **Learn glossary** (new `GlossaryOverlay`) — a "Decode poker shorthand" reference covering hand notation, strength tiers, position tags (BTN/SB/BB), and card notation. Hand-class examples read through `describeHandClass` so they can't drift from the chart.

### 2. Stop Learn lesson titles repeating the subtitle (`fix`)
The path rendered the full title *plus* the subtitle (`Equity: your share of the pot · your share of the pot`). Render the title head + subtitle instead. Extracted a shared `lessonHead()` so `LearnView` and `LessonPlayer` can't drift.

### 3. Stop the action bar resizing as the turn passes (`fix`)
The bar's height tracked the turn (bot "Waiting…" ~72px → hero turn ~138px), bouncing the table each action. Floor it at the tallest layout and anchor controls to the bottom. Verified live at 414px and 360px: all states 140px, buttons on the same bottom edge.

**Verification:** `pnpm verify` green locally — format, lint, typecheck, 557 tests, coverage thresholds. New tests cover `describeHandClass`, the chart caption (tap + seeded), the glossary, and the lesson-title split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)