### PR TITLE
Fix M5.5 CI test timeouts (equity-heavy drill sweeps)

### DIFF
--- a/packages/drills/src/generate.test.ts
+++ b/packages/drills/src/generate.test.ts
@@ -25,10 +25,12 @@ const SEEDS = Array.from({ length: 40 }, (_, i) => i + 1)
 
 /**
  * A smaller seed slice for the invariants whose grade runs the coach's Monte-Carlo equity read
- * (`coachDecision`, ~4000 iterations per choice). A handful of distinct deals is plenty to prove the
- * no-answer-key invariant — the property is structural, not statistical — and keeps the suite fast.
+ * (`coachDecision`, ~4000 iterations per choice — and the turn/river + Call/Raise/Fold sweeps run it
+ * several times per spot). A handful of distinct deals is plenty to prove the no-answer-key invariant —
+ * the property is structural, not statistical — and keeping this small is what keeps these sweeps well
+ * under the per-test timeout on CI's contended 2-core runner (they were the M5.5 CI timeouts).
  */
-const COACH_SEEDS = SEEDS.slice(0, 8)
+const COACH_SEEDS = SEEDS.slice(0, 4)
 
 /** Every physical card a spot touches — hole cards plus any board — for the duplicate/legality checks. */
 function allCards(spot: CoachSpot | PreflopSpot): Card[] {

--- a/packages/drills/src/themes.test.ts
+++ b/packages/drills/src/themes.test.ts
@@ -15,8 +15,14 @@ import {
   type SessionItem,
 } from './themes.js'
 
-/** A spread of session seeds to exercise the composer across many distinct draws. */
-const SEEDS = Array.from({ length: 20 }, (_, i) => i + 1)
+/**
+ * A spread of session seeds to exercise the composer across many distinct draws. Kept to 10 because the
+ * structural sweeps compose over the full catalogue — which includes the `equity-estimate` theme that
+ * runs the coach's Monte-Carlo equity read at GENERATION — so each composed session is several equity
+ * sims; 10 distinct seeds proves the (structural, not statistical) interleave/determinism invariants
+ * while keeping these sweeps well under the per-test timeout on CI's contended 2-core runner.
+ */
+const SEEDS = Array.from({ length: 10 }, (_, i) => i + 1)
 
 /** Look a theme up by id — the catalogue is small, so a find is fine and keeps the tests readable. */
 function theme(id: string): DrillTheme {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,8 +16,11 @@ export default defineConfig({
     // instrumentation on a 2-core runner with every test file contending, which is several times
     // slower, so the stock 5s per-test timeout trips them. Raise the global floor well past that;
     // the single heaviest spot (exact preflop enumeration) sets its own larger timeout inline.
-    testTimeout: 60_000,
-    hookTimeout: 60_000,
+    // The M5.5 drill sweeps grade spots through the coach's Monte-Carlo equity read (and the
+    // equity-estimate theme runs one at generation), so their seed sweeps are kept small AND the
+    // floor is 120s — several × the worst observed CI time — so contention can never trip them.
+    testTimeout: 120_000,
+    hookTimeout: 120_000,
     coverage: {
       provider: 'v8',
       // The pure, correctness-critical packages every later milestone trusts — the engine


### PR DESCRIPTION
The M5.5 merge to `main` turned CI red — 4 drill tests hit the 60s per-test timeout on CI's contended 2-core runner (not flaky, not a logic bug; both CI and Deploy failed identically).

**Root cause:** the M5.5 `equity-estimate` theme runs a Monte-Carlo equity read at generation, and the no-answer-key sweeps grade every choice through the coach (another Monte-Carlo, twice per choice), so the `COACH_SEEDS`(8)/`SEEDS`(20) sweeps were hundreds of equity sims per test. It passed local `verify` (fast machine) and the feature-branch pushes never ran main's CI, so it only surfaced post-merge.

**Fix** (structural invariants, so fewer seeds preserves intent):
- `generate.test.ts` `COACH_SEEDS` 8 → 4 (turn/river 14s→8s, Call/Raise/Fold 20s→11s locally)
- `themes.test.ts` `SEEDS` 20 → 10 (omitted-bias 12s→5s, interleave 9s→4s)
- `vitest` `testTimeout` 60s → 120s for margin

Worst remaining test ~11s local (~40s CI worst-case) — comfortable under 120s. `pnpm verify` green; coverage unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)