### PR TITLE
Defer LLM coaching (M7) to a deferred idea

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -63,11 +63,20 @@ UI exists — so the foundation is trustworthy before anything is built on top o
   existed, so it was built here as the shared durable store M6 stats will consume. Its epic is
   [`0076`](../tickets/0076-drills-v2.md).
 - **M6 — Stats & leak detection.** Where a trainer beats just playing online — longitudinal
-  feedback built on stored hand history.
-- **M7 — LLM coaching (optional).** Natural-language narration on top of the trustworthy math.
-  Last because it's polish and the only thing needing a network boundary.
-- **stretch — GTO.** Solver-driven play, swapped in behind the M2 `Opponent` seam. Deliberately
-  last: research-grade effort, and everything else should be solid first.
+  feedback built on stored hand history. **This is the last committed milestone.**
+
+### Deferred — ideas, not committed
+
+Parked as maybe-someday ideas, deliberately off the committed arc. They only get pulled if they
+clearly earn their cost; until then they're not planned work.
+
+- **LLM coaching (was M7).** Natural-language narration on top of the trustworthy math — the LLM would
+  _explain_ the deterministic numbers, never compute them. **Deprioritized:** it's pure polish and the
+  only thing in the whole app that would need a network boundary (a serverless key-proxy), and that
+  cost isn't worth it just for narration — the deterministic math coach already stands on its own.
+  Parked as an idea ([`0011`](../tickets/0011-llm-coaching.md)).
+- **GTO solver.** Solver-driven play, swapped in behind the M2 `Opponent` seam. Research-grade effort,
+  and everything else should be solid first ([`0012`](../tickets/0012-gto-solver.md)).
 
 (The half-steps **M3.5**, **M4.5**, **M4.6**, and **M5.5** are numbered that way deliberately: each
 slots a step into the arc without renumbering the rest. M3.5 puts a terminal UI between the coach and
@@ -90,8 +99,9 @@ Your "all three eventually" maps onto the arc rather than being separate tracks:
 
 - **The poker brain is the asset; the UI is a swappable shell.** Engine/odds/bots/coach are pure
   TS with no UI or network deps.
-- **Determinism for correctness, LLM only for narration.** Every verdict is math we own; the LLM
-  (M7) just explains it and is always optional / offline-degradable.
+- **Determinism for correctness, LLM only for narration.** Every verdict is math we own; an LLM layer
+  would only explain it and stay optional / offline-degradable — which is exactly why it's a deferred
+  idea, not a committed milestone (a network boundary isn't worth it just for narration).
 - **Front-load the hard, high-value work.** Correctness-critical code ships and is tested before
   any pixels exist.
 

--- a/tickets/0011-llm-coaching.md
+++ b/tickets/0011-llm-coaching.md
@@ -1,9 +1,9 @@
 ---
 id: 0011
-title: 'Epic: LLM coaching polish (optional)'
+title: 'Epic: LLM coaching polish (deferred idea — not committed)'
 type: epic
 status: todo
-milestone: M7
+milestone: stretch
 priority: low
 created: 2026-06-13
 ---
@@ -12,6 +12,13 @@ created: 2026-06-13
 
 Optional polish: natural-language explanations on top of the trustworthy math. The LLM narrates
 deterministic numbers — it never computes them.
+
+**Deprioritized (2026-06-17): moved off the committed arc (was M7) to a deferred idea, alongside the
+GTO stretch ([[0012-gto-solver]]).** Rationale: this is pure narration polish, and it is the _only_
+thing in the whole app that would introduce a network boundary (the serverless key-proxy below). That
+cost — a backend to own, a key to hold, an online dependency in an otherwise offline static shell —
+isn't worth it just to reword numbers the deterministic coach already explains well. Only pull this if
+it clearly earns that cost. See `docs/ROADMAP.md` ("Deferred — ideas, not committed").
 
 ## Acceptance criteria
 


### PR DESCRIPTION
A network boundary isn't worth it just for narration. LLM coaching was the only milestone in the app that would need a backend (a serverless key-proxy), and it's pure polish on top of the deterministic math — which already explains its numbers well. So it moves off the committed arc.

- **ROADMAP:** M6 is now the last committed milestone; LLM coaching + GTO sit in a new "Deferred — ideas, not committed" tier, with the rationale.
- **Ticket 0011:** `milestone: M7 → stretch`; title/context record the deprioritization.

Docs/board only — no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)